### PR TITLE
Adjust Bundle Location to Support Swift Frameworks

### DIFF
--- a/Classes/User/SparkSetupMainController.m
+++ b/Classes/User/SparkSetupMainController.m
@@ -36,7 +36,7 @@ NSString *const kSparkSetupDidLogoutNotification = @"kSparkSetupDidLogoutNotific
 
 +(NSBundle *)getResourcesBundle
 {
-    NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"SparkSetup" withExtension:@"bundle"]];
+    NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle bundleForClass:[self class]] URLForResource:@"SparkSetup" withExtension:@"bundle"]];
     return bundle;
 }
 
@@ -49,8 +49,7 @@ NSString *const kSparkSetupDidLogoutNotification = @"kSparkSetupDidLogoutNotific
 
 +(UIImage *)loadImageFromResourceBundle:(NSString *)imageName
 {
-//    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"SparkSetup" withExtension:@"bundle"]];
+    NSBundle *bundle = [SparkSetupMainController getResourcesBundle]
     NSString *imageFileName = [NSString stringWithFormat:@"%@.png",imageName];
     UIImage *image = [UIImage imageNamed:imageFileName inBundle:bundle compatibleWithTraitCollection:nil];
     return image;


### PR DESCRIPTION
Fixes #32 by using `[NSBundle bundleForClass:[self class]]` as suggested by CocoaPods in their release notes for 0.36 (http://blog.cocoapods.org/CocoaPods-0.36/).

Tested with a Swift 2.1 iOS project in Xcode 7 with CocoaPods `use_frameworks!`. Before the changes, `SparkSetupMainController()` would return `nil` due to the exception as described in #32. After the changes the bundle is found, so the controller is returned correctly.

Note-- I have NOT tested this on a new Objective-C project yet.
